### PR TITLE
SMTP: on 3xx response to 'AUTH XOAUTH2' send CR-LF to get actual error.

### DIFF
--- a/lib/gmail_xoauth/smtp_xoauth2_authenticator.rb
+++ b/lib/gmail_xoauth/smtp_xoauth2_authenticator.rb
@@ -3,14 +3,31 @@ require 'base64'
 
 module GmailXoauth
   module SmtpXoauth2Authenticator
-    
+
+    def send_xoauth2(auth_token)
+      critical {
+        get_response("AUTH XOAUTH2 #{auth_token}")
+      }
+    end
+    private :send_xoauth2
+
+    def get_final_status
+      critical {
+        get_response("")
+      }
+    end
+    private :get_final_status
+
     def auth_xoauth2(user, oauth2_token)
       check_auth_args user, oauth2_token
 
       auth_string = build_oauth2_string(user, oauth2_token)
-      res = critical {
-        get_response("AUTH XOAUTH2 #{base64_encode(auth_string)}")
-      }
+      res = send_xoauth2(base64_encode(auth_string))
+
+      # See note about SMTP protocol exchange in https://developers.google.com/gmail/xoauth2_protocol
+      if res.continue?
+        res = get_final_status
+      end
       
       check_auth_response res
       res

--- a/lib/gmail_xoauth/version.rb
+++ b/lib/gmail_xoauth/version.rb
@@ -1,3 +1,3 @@
 module GmailXoauth
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,7 +2,7 @@ require 'yaml'
 
 require 'rubygems'
 require 'test/unit'
-require 'mocha'
+require 'mocha/test_unit'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))

--- a/test/test_smtp_xoauth2_authenticator.rb
+++ b/test/test_smtp_xoauth2_authenticator.rb
@@ -29,4 +29,30 @@ class TestSmtpXoauthAuthenticator < Test::Unit::TestCase
   ensure
     smtp.finish if smtp && smtp.started?
   end
+
+  # Test the handling of 3xx response to an "AUTH XOAUTH2" request... client
+  # should send a "\r\n" to get the actual error that occurred.
+  #
+  # See note about SMTP protocol exchange in https://developers.google.com/
+  # gmail/xoauth2_protocol
+  #
+  def test_authenticate_with_continuation
+    smtp = Net::SMTP.new('smtp.gmail.com', 587)
+
+    # Stub return from initial "AUTH XOAUTH2" request as well as the empty line sent to get final error
+    smtp.stubs(:send_xoauth2).returns(Net::SMTP::Response.parse("334 eyJzdGF0dXMiOiI0MDAiLCJzY2hlbWVzIjoiQmVhcmVyIiwic2NvcGUiOiJodHRwczovL21haWwuZ29vZ2xlLmNvbS8ifQ=="))
+    smtp.stubs(:get_final_status).returns(Net::SMTP::Response.parse("454 4.7.0 Too many login attempts, please try again later. j63sm3521185itj.19 - gsmtp"))
+
+    smtp.enable_starttls_auto
+
+    # Validate an error is still raised
+    ex = assert_raise(Net::SMTPAuthenticationError) do
+      smtp.start('gmail.com', 'roger@moore.com', 'a', :xoauth2)
+    end
+
+    # ...and that the 334 is not passed back to the caller.
+    assert_equal("454 4.7.0 Too many login attempts, please try again later. j63sm3521185itj.19 - gsmtp", ex.message)
+  ensure
+    smtp.finish if smtp && smtp.started?
+  end
 end


### PR DESCRIPTION
See the note in https://developers.google.com/gmail/xoauth2_protocol which
explains this bit ('note about SMTP protocol exchange').  Apparently, we'd
all missed it for years.
